### PR TITLE
Meetings: upper/lower item to flex and directives to scroll

### DIFF
--- a/app/directives/proposalList/proposalList.directive.html
+++ b/app/directives/proposalList/proposalList.directive.html
@@ -1,4 +1,4 @@
-<div class="proposal-list">
+<div class="proposal-list db-overflow">
 
     <div class="col-xs-12 db-nopadding">
         <ul class="list-group">

--- a/app/directives/remark/remark.directive.html
+++ b/app/directives/remark/remark.directive.html
@@ -1,4 +1,4 @@
-<div class="remark">
+<div class="remark db-overflow">
 
     <div class="col-xs-12 db-nopadding">
         <ul class="list-group">

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -904,12 +904,10 @@ body {
 }
 
 .db-conf-att {
-    background-color: white;
-
     flex: 1;
     display: flex;
     flex-direction: column;
-
+    background-color: white;
     .pagination {
         margin: 5px 0px;
     }

--- a/app/styles/proposal.scss
+++ b/app/styles/proposal.scss
@@ -9,7 +9,7 @@ $font-color: white;
 $btn-radius: 6px;
 
 .proposal-list {
-    width: 100%;
+    flex: 1;
 
     span.glyphicon {
         font-size: 1.0em !important;

--- a/app/styles/remark.scss
+++ b/app/styles/remark.scss
@@ -8,7 +8,7 @@
 $font-color: white;
 
 .remark {
-    width: 100%;
+    flex: 1;
 
     span.glyphicon {
         font-size: 1.0em !important;

--- a/app/views/meeting.details.html
+++ b/app/views/meeting.details.html
@@ -105,8 +105,8 @@
                     ng-attr-uri="ctrl.lowerUrl" ng-attr-size="ctrl.lowerSize" ng-attr-no-content="ctrl.noContent"></db-pdf>
                 <db-imgviewer ng-if="(ctrl.lbm === ctrl.lbms.ATTACHMENTS || ctrl.lbm === ctrl.lbms.MATERIALS) && ctrl.isSecret(ctrl.lowerAtt)"
                     file-conf="ctrl.lowerAtt"></db-imgviewer>
-                <db-remark ng-if="ctrl.lbm === ctrl.lbms.REMARK" topic="ctrl.topic" class="db-overflow"></db-remark>
-                <db-proposal-list ng-if="ctrl.lbm === ctrl.lbms.PROPOSALS" topic="ctrl.topic" class="db-overflow"></db-proposal-list>
+                <db-remark ng-if="ctrl.lbm === ctrl.lbms.REMARK" topic="ctrl.topic"></db-remark>
+                <db-proposal-list ng-if="ctrl.lbm === ctrl.lbms.PROPOSALS" topic="ctrl.topic"></db-proposal-list>
             </div>
 
 


### PR DESCRIPTION
The other way around, item scrolling and w/h to 100% for directives, was ok otherwise but not on IE11.
Using this until the IE issue is solved.
