### PR TITLE
Pdf directive url arg separator resolving fix

### DIFF
--- a/app/directives/pdf/pdf.directive.js
+++ b/app/directives/pdf/pdf.directive.js
@@ -28,10 +28,7 @@ angular.module('dashboard')
                 var isIe = $rootScope.isIe;
 
                 function paramSeparator(uri) {
-                    if (angular.isString(uri)) {
-                        return CONST.NOTFOUND === uri.indexOf('?') ? '?' : '&';
-                    }
-                    return true;
+                    return angular.isString(uri) && (CONST.NOTFOUND !== uri.indexOf('?')) ? '&' : '?';
                 }
 
                 function hide() {


### PR DESCRIPTION
Function is expected to return always a character instead of boolean.
