### PR TITLE
Mobile attachment selection list and handling

### DIFF
--- a/app/directives/imgviewer/imgviewer.directive.html
+++ b/app/directives/imgviewer/imgviewer.directive.html
@@ -1,4 +1,4 @@
-<div class="db-directive">
+<div class="db-directive db-conf-att">
 
     <div class="db-hdr-l2">
 
@@ -12,13 +12,13 @@
                 <span translate translate-cloak>STR_PAGE</span>
             </div>
 
-            <div class="db-hdr-l2-item btn-group">
-                <button type="button" class="hidden-xs btn btn-primary btn-lg" ng-click="c.pageChanged(1)" ng-disabled="c.currPage === 1 || !c.pages.length">
+            <div class="db-hdr-l2-item">
+                <button type="button" class="hidden-xs btn db-btn-prim btn-md" ng-click="c.pageChanged(1)" ng-disabled="c.currPage === 1 || !c.pages.length">
                     <span ng-if="c.pages.length > 1">(1)&nbsp;</span>
                     &lt;&lt;
                 </button>
 
-                <button type="button" class="btn btn-primary btn-lg" ng-click="c.pageChanged(c.currPage - 1)" ng-disabled="c.currPage === 1 || !c.pages.length">
+                <button type="button" class="btn db-btn-prim btn-md" ng-click="c.pageChanged(c.currPage - 1)" ng-disabled="c.currPage === 1 || !c.pages.length">
                     &lt;
                 </button>
             </div>
@@ -28,12 +28,12 @@
                     required ng-disabled="!c.pages.length || c.pages.length === 1">
             </div>
 
-            <div class="db-hdr-l2-item btn-group">
-                <button type="button" class="btn btn-primary btn-lg" ng-click="c.pageChanged(c.currPage + 1)" ng-disabled="c.currPage >= c.pages.length">
+            <div class="db-hdr-l2-item">
+                <button type="button" class="btn db-btn-prim btn-md" ng-click="c.pageChanged(c.currPage + 1)" ng-disabled="c.currPage >= c.pages.length">
                     &gt;
                 </button>
 
-                <button type="button" class="hidden-xs btn btn-primary btn-lg" ng-click="c.pageChanged(c.pages.length)" ng-disabled="c.currPage >= c.pages.length">
+                <button type="button" class="hidden-xs btn db-btn-prim btn-md" ng-click="c.pageChanged(c.pages.length)" ng-disabled="c.currPage >= c.pages.length">
                     &gt;&gt;&nbsp;
                     <span ng-if="c.pages.length > 1">({{c.pages.length}})</span>
                 </button>
@@ -42,12 +42,12 @@
         </div>
 
         <div class="db-hdr-l2-grp">
-            <div class="db-hdr-l2-item hidden-xs hidden-sm">
+            <div class="db-hdr-l2-item hidden-xs hidden-md">
                 <span translate translate-cloak>STR_ZOOM</span>
             </div>
 
             <div class="db-hdr-l2-item">
-                <button type="button" class="btn btn-primary btn-lg" ng-click="c.imgZoom(true)" ng-disabled="!c.pages.length || !c.currPage">
+                <button type="button" class="btn db-btn-prim btn-md" ng-click="c.imgZoom(true)" ng-disabled="!c.pages.length || !c.currPage">
                     <span class="glyphicon center glyphicon-minus"></span>
                 </button>
             </div>
@@ -57,7 +57,7 @@
             </div>
 
             <div class="db-hdr-l2-item">
-                <button type="button" class="btn btn-primary btn-lg" ng-click="c.imgZoom(false)" ng-disabled="!c.pages.length || !c.currPage">
+                <button type="button" class="btn db-btn-prim btnmd" ng-click="c.imgZoom(false)" ng-disabled="!c.pages.length || !c.currPage">
                     <span class="glyphicon center glyphicon-plus"></span>
                 </button>
             </div>

--- a/app/directives/selectionList/selectionList.directive.html
+++ b/app/directives/selectionList/selectionList.directive.html
@@ -5,15 +5,17 @@
             <div class="db-flex db-center-v">
                 <span class="db-margin-10-right glyphicon ng-class:{'glyphicon-minus': !isCollapsed, 'glyphicon-plus': isCollapsed}" aria-hidden="true"></span>
                 <h5 ng-if="data.title.header" translate translate-cloak>{{data.title.header}}</h5>
+                &nbsp;&nbsp;
+                <span class="badge db-badge-hdr ng-cloak">{{data.objects.length}}</span>
             </div>
         </div>
         <div uib-collapse="isCollapsed">
             <li class="list-group-item ng-class:[{'db-opacity-05':c.isLinkDisabled(att)}]" ng-repeat="att in data.objects track by $index">
                 <div class="db-flex">
                     <a class="db-flex-area" ng-click="!c.isLinkDisabled(att) && c.selected(att)"><span ng-if="att.orderNum">{{att.orderNum}}&nbsp;</span>{{att.title}}</a>
-                    <span ng-if="!c.isMobile" class="glyphicon glyphicon-new-window ng-class:[{'db-opacity-05':c.isOpenWindowDisabled(att)}]" ng-click="!c.isOpenWindowDisabled(att) && c.newTab(att.link)" aria-hidden="true"></span>
+                    <span ng-if="!c.isMobile" class="glyphicon glyphicon-new-window ng-class:[{'db-opacity-05':c.isOpenWindowDisabled(att)}]"
+                        ng-click="!c.isOpenWindowDisabled(att) && c.newTab(att.link)" aria-hidden="true"></span>
                 </div>
-
             </li>
         </div>
     </ul>

--- a/app/loc/lang-fi.json
+++ b/app/loc/lang-fi.json
@@ -107,7 +107,7 @@
     "STR_INFO_NEW_PROPS": "Uusia lukemattomia ehdotuksia",
     "STR_WARNING_UNSAVED": "Työpöydällä on tallentamattomia tietoja. Haluatko jatkaa tallentamatta?",
     "STR_TOPIC_LIST": "Asialista",
-    "STR_CONTENT": "Sisältö",
+    "STR_TOPIC": "Asia",
     "STR_CONTINUE": "Jatka",
     "STR_PUBLISHED": "Julkaistu",
     "STR_SAVE_SUCCESS": "Tallennus onnistui",

--- a/app/scripts/controllers/list.ctrl.js
+++ b/app/scripts/controllers/list.ctrl.js
@@ -8,10 +8,11 @@
  * Controller of the dashboard
  */
 angular.module('dashboard')
-    .controller('listCtrl', ['$log', '$scope', '$state', 'StorageSrv', 'CONST', 'Utils', function ($log, $scope, $state, StorageSrv, CONST, Utils) {
+    .controller('listCtrl', ['$log', '$scope', '$state', 'StorageSrv', 'CONST', 'Utils', 'AttachmentData', function ($log, $scope, $state, StorageSrv, CONST, Utils, AttachmentData) {
         $log.debug("listCtrl: CONTROLLER");
         var self = this;
-        self.data = StorageSrv.getKey(CONST.KEY.SELECTION_DATA);
+
+        self.data = StorageSrv.getKey(CONST.KEY.SELECTION_DATA); // Expects an array if ListData items
         self.isAttConf = Utils.isAttConf;
 
         // att: AttachmentData
@@ -23,6 +24,20 @@ angular.module('dashboard')
 
             StorageSrv.setKey(CONST.KEY.LIST_ATT, att);
             $state.go(CONST.APPSTATE.MTG_LIST_ATTACHMENT);
+        };
+
+        self.selAtt = function (aArg) {
+            if (!(aArg instanceof AttachmentData)){
+                $log.error("listCtrl.selAtt: ignored due to bad args " + AttachmentData);
+                return;
+            }
+
+            if (!Utils.isAttConf(aArg)) {
+                Utils.openNewWin(aArg.link);
+            } else {
+                StorageSrv.setKey(CONST.KEY.LIST_ATT, aArg);
+                $state.go(CONST.APPSTATE.MTG_LIST_ATTACHMENT);
+            }
         };
 
         $scope.$on('$destroy', function () {

--- a/app/scripts/controllers/meeting.details.ctrl.js
+++ b/app/scripts/controllers/meeting.details.ctrl.js
@@ -168,7 +168,7 @@ angular.module('dashboard')
         self.attachmentClicked = function (attachment) {
             setLowerBlockMode(CONST.LOWERBLOCKMODE.ATTACHMENTS);
             if (isMobile) {
-                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, self.aData);
+                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, [self.aData]);
                 $state.go(CONST.APPSTATE.LIST);
             }
             else if (attachment instanceof Object) {
@@ -183,7 +183,7 @@ angular.module('dashboard')
         self.decisionClicked = function (decision) {
             setLowerBlockMode(CONST.LOWERBLOCKMODE.MATERIALS);
             if (isMobile) {
-                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, self.dData);
+                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, [self.dData]);
                 $state.go(CONST.APPSTATE.LIST);
             }
             else if (decision instanceof Object) {
@@ -197,7 +197,7 @@ angular.module('dashboard')
         self.additionalMaterialClicked = function (material) {
             setLowerBlockMode(CONST.LOWERBLOCKMODE.MATERIALS);
             if (isMobile) {
-                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, self.amData);
+                StorageSrv.setKey(CONST.KEY.SELECTION_DATA, [self.amData]);
                 $state.go(CONST.APPSTATE.LIST);
             }
             else if (material instanceof Object) {

--- a/app/scripts/services/utils.srv.js
+++ b/app/scripts/services/utils.srv.js
@@ -96,5 +96,14 @@ angular.module('dashboard')
             return res;
         };
 
+        Utils.openNewWin = function (aUrl) {
+            if (angular.isString(aUrl) && aUrl.length) {
+                $window.open(aUrl, '_blank');
+            }
+            else {
+                $log.error("Utils.openNewWin: ignored due to bad url " + aUrl);
+            }
+        };
+
         return Utils;
     });

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -623,11 +623,15 @@ body {
     .db-btn-prim {
         @include button-variant($font-color-header, $db-color-448AFF, $db-color-448AFF);
         color: $db-color-FFFFFF;
+
+
     }
 
     .db-btn-prim.active {
         @include button-variant($font-color-header, $db-color-303F9F-lighten, $db-color-303F9F-lighten);
     }
+
+
 
     .db-btn-opt {
         @include button-variant($font-color-header, $db-color-303F9F, $db-color-303F9F);
@@ -1158,32 +1162,10 @@ body {
 }
 
 .db-conf-att {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    background-color: white;
-    .pagination {
-        margin: 5px 0px;
-    }
-    .pagination-first, .pagination-last, .pagination-prev, .pagination-next {
-        a {
-            font-weight: bold;
-        }
-    }
-
     input[type="number"] {
-        width: 4.5em;
+        width: 4em;
         margin: 0;
     }
-
-    .db-conf-att-img {
-        flex: 1;
-        overflow: auto;
-       .bigger {
-            width: 200vw;
-        }
-    }
-
 }
 
 .db-spinner-cont {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -32,7 +32,7 @@ $db-color-B6B6B6: #B6B6B6;
 
 $appbgcolor: white;
 $font-color-body: #404040;
-$headingBgColor: $db-color-303F9F;
+$headingBgColor: $db-color-448AFF;
 
 $default-font-size: 1.2em;
 $font-weight-600: 600;
@@ -614,6 +614,10 @@ body {
 
     .db-badge-ora {
         @include db-badge-mix(#f0ad4e, $badge-font-color-dark, $badge-font-color-dark);
+    }
+
+    .db-badge-hdr {
+        @include db-badge-mix($font-color-header, $headingBgColor, $headingBgColor);
     }
 
     .db-btn-prim {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -644,6 +644,13 @@ body {
         @include button-variant($font-color-header, $db-color-303F9F-lighten, $db-color-303F9F-lighten);
     }
 
+    .db-btn-sel[disabled],
+    .db-btn-sel[disabled]:hover,
+    .db-btn-sel[disabled]:focus,
+    .db-btn-sel[disabled]:active {
+        color: $font-color-header; // Disable hover effect for disabled button
+    }
+
     .db-btn-succ {
         @include button-variant($font-color-header, $db-color-success, $db-color-success);
     }

--- a/app/views/list.html
+++ b/app/views/list.html
@@ -8,26 +8,7 @@
     </div>
 
     <div class="ad-page-content">
-
-    <!-- TODO: take db-selection list into use and implement mobile support. Signing atts would already be displayed
-        <db-selection-list ng-attr-sel-data="c.data" ng-attr-on-select="c.selAtt(data)"></db-selection-list>-->
-
-        <h5 class="db-title" ng-cloak>{{c.data.title.title}}</h5>
-        <div class="ad-mob-page-container">
-            <ul class="list-group db-attlist">
-
-                <li ng-repeat="i in c.data.objects track by $index">
-                    <db-link ng-if="!c.isAttConf(i)" ng-attr-config="{ title: i.orderNum + '&nbsp;' + i.title, class:'list-group-item' }" ng-attr-uri="i.link">
-                    </db-link>
-
-                    <button ng-if="c.isAttConf(i)" class="btn btn-block btn-lg" ng-click="c.goToFile(i)">
-                        <img ng-src="../images/conf-lock.png">
-                        <span>{{i.orderNum}}&nbsp;{{i.title}}</span>
-                    </button>
-                </li>
-
-            </ul>
-        </div>
+        <db-selection-list ng-attr-sel-data="c.data" ng-attr-on-select="c.selAtt(data)"></db-selection-list>
     </div>
 
 </div>

--- a/app/views/meeting.details.html
+++ b/app/views/meeting.details.html
@@ -41,12 +41,12 @@
                     <span class="glyphicon ng-class:[{'glyphicon-minus':c.bm === c.bms.SECONDARY},{'glyphicon-plus':c.bm !== c.bms.SECONDARY}]"></span>
                 </button>
 
-                <button type="button" class="btn db-btn-sel db-btn-big db-brd db-margin-2 ng-class:[{'active':c.lbm === c.lbms.ATTACHMENTS}]"
+                <button type="button" class="btn db-btn-sel db-btn-big db-brd db-margin-2 ng-class:[{'active':c.lbm === c.lbms.ATTACHMENTS}]" ng-disabled="!c.aData.objects.length"
                     db-confirm confirm-enabled="c.hasUnsavedProposal || c.remarkIsUnsaved" confirm-config="c.unsavedConfig" ng-click="c.attClicked()">
                     <span translate translate-cloak>STR_ATTACHMENTS</span>
                     <span ng-if="c.aData.objects.length" class="badge ng-cloak">{{c.aData.objects.length}}</span>
                 </button>
-                <button type="button" class="btn db-btn-sel db-btn-big db-brd db-margin-2 ng-class:[{'active':c.lbm === c.lbms.MATERIALS}]"
+                <button type="button" class="btn db-btn-sel db-btn-big db-brd db-margin-2 ng-class:[{'active':c.lbm === c.lbms.MATERIALS}]" ng-disabled="!c.materialCount()"
                     db-confirm confirm-enabled="c.hasUnsavedProposal || c.remarkIsUnsaved" confirm-config="c.unsavedConfig" ng-click="c.matClicked()">
                     <span translate translate-cloak>STR_OTHER_MATERIAL</span>
                     <span ng-if="c.materialCount()" class="badge ng-cloak">{{c.materialCount()}}</span>

--- a/app/views/meeting.details.html
+++ b/app/views/meeting.details.html
@@ -87,7 +87,7 @@
         <button type="button" class="btn db-btn-prim db-no-margin" ng-click="goBack()">
             <span class="glyphicon glyphicon-menu-left"></span>
         </button>
-        <h4 translate translate-cloak>STR_CONTENT</h4>
+        <h4 translate translate-cloak>STR_TOPIC</h4>
     </div>
 
     <div ng-if="isMobile" class="ad-page-content">


### PR DESCRIPTION
- Meetings and Signing to use db-selection to display attachments lists both on mobile and desktop
- Polish imgViewer style for confidential attachments
- On mobile download pdf's by opening a new window via javascript, or transition to confidential viewer
- To be done in next PR: potential custom visualisation of different attachment item types
