### PR TITLE
Tablet layout support for signing views

### DIFF
--- a/app/scripts/controllers/sign.details.ctrl.js
+++ b/app/scripts/controllers/sign.details.ctrl.js
@@ -12,11 +12,12 @@
  * Controller of the dashboard
  */
 var app = angular.module('dashboard');
-app.controller('signDetailsCtrl', function ($log, $state, $rootScope, ENV, CONST, StorageSrv, ListData, SigningUtil) {
+app.controller('signDetailsCtrl', function ($log, $state, $rootScope, ENV, CONST, StorageSrv, ListData, SigningUtil, Utils) {
     $rootScope.menu = CONST.MENU.FULL;
 
     var self = this;
     self.isMobile = $rootScope.isMobile;
+    self.isTablet = $rootScope.isTablet;
     self.bms = CONST.BLOCKMODE;
     self.bm = CONST.BLOCKMODE.DEFAULT;
 
@@ -194,6 +195,10 @@ app.controller('signDetailsCtrl', function ($log, $state, $rootScope, ENV, CONST
         });
         // $log.debug("signDetailsCtrl.isLoadingSec: " + res);
         return res;
+    };
+
+    self.openDoc = function (btnModelItem) {
+        Utils.openNewWin(btnModelItem.url);
     };
 
     initCtrl(self.btnModel, self.item, self.item.Status);

--- a/app/scripts/services/utils.srv.js
+++ b/app/scripts/services/utils.srv.js
@@ -98,6 +98,7 @@ angular.module('dashboard')
 
         Utils.openNewWin = function (aUrl) {
             if (angular.isString(aUrl) && aUrl.length) {
+                $log.debug("Utils.openNewWin: " + aUrl);
                 $window.open(aUrl, '_blank');
             }
             else {

--- a/app/views/sign.details.html
+++ b/app/views/sign.details.html
@@ -3,11 +3,12 @@
     <div class="ng-class:[{'ad-page-container-flex-row':parallelMode},{'ad-page-container-flex':!parallelMode}]">
 
         <!-- PRIMARY BLOCK START-->
-        <div class="db-block db-margin-05 ng-class:[{'db-block-close':c.bm === c.bms.SECONDARY},{'db-block-open':c.bm !== c.bms.SECONDARY}]">
+        <div ng-if="!c.isTablet" class="db-block db-margin-05 ng-class:[{'db-block-close':c.bm === c.bms.SECONDARY},{'db-block-open':c.bm !== c.bms.SECONDARY}]">
 
             <!-- PRIMARY BLOCK HEADER -->
             <div class="btn-group db-flex-wrap db-prim-bg db-brd-top db-padding-2">
-                <button ng-if="menuClosed()" type="button" class="btn db-btn-prim db-btn-small db-brd-all db-margin-2" ng-click="openMenu()" tooltip-enable="isTooltips" uib-tooltip="{{'STR_INFO_MENUBTN' | translate}}" tooltip-placement="right">
+                <button ng-if="menuClosed()" type="button" class="btn db-btn-prim db-btn-small db-brd-all db-margin-2" ng-click="openMenu()"
+                    tooltip-enable="isTooltips" uib-tooltip="{{'STR_INFO_MENUBTN' | translate}}" tooltip-placement="right">
                     <span class="glyphicon glyphicon-th-list"></span>
                 </button>
                 <button ng-if="menuClosed()" type="button" class="btn db-btn-prim db-btn-small db-brd-all db-margin-2" ng-click="c.toggleParallelMode()">
@@ -45,8 +46,17 @@
             <!-- SECONDARY BLOCK HEADER -->
             <div class="btn-group db-flex-wrap db-prim-bg db-brd-top db-padding-2">
 
-                <button type="button" class="btn db-btn-prim db-btn-small db-brd-all db-margin-2" ng-disabled="parallelMode" ng-click="c.secondaryClicked()">
+                <button ng-if="!c.isTablet" type="button" class="btn db-btn-prim db-btn-small db-brd-all db-margin-2" ng-disabled="parallelMode"
+                    ng-click="c.secondaryClicked()">
                     <span class="glyphicon ng-class:[{'glyphicon-minus':c.bm === c.bms.SECONDARY},{'glyphicon-plus':c.bm !== c.bms.SECONDARY}]""></span>
+                </button>
+
+                <button type="button" class="btn db-btn-sel db-btn-big db-brd-all db-margin-2" ng-click="c.openDoc(c.btnModel.doc)">
+                    <span translate translate-cloak>STR_SIGNING_REQ</span>
+                </button>
+
+                <button type="button" class="btn db-btn-sel db-btn-big db-brd-all db-margin-2" ng-click="c.openDoc(c.btnModel.doctr)" ng-disabled="c.btnModel.doctr.disabled">
+                    <span translate translate-cloak>STR_TRANSLATION</span>
                 </button>
 
                 <button type="button" class="btn db-btn-sel db-btn-big db-brd-all db-margin-2 ng-class:[{ 'active' : c.isActive(c.btnModel.att.id) }]"


### PR DESCRIPTION
Only pdf format supported so hides primary block for embedded pdf on tablet when it uses desktop layout.
Buttons for downloading pdf docs added to secondary block header.
