### PR TITLE
Hide emb pdf on IE durin mtg status change dialog

### DIFF
--- a/app/scripts/controllers/meeting.status.ctrl.js
+++ b/app/scripts/controllers/meeting.status.ctrl.js
@@ -65,6 +65,14 @@ angular.module('dashboard')
                     }]
                 });
 
+                modalInstance.opened.then(function () {
+                    $rootScope.$emit(CONST.CONFIRMACTIVE, { 'open': true });
+                });
+
+                modalInstance.closed.then(function () {
+                    $rootScope.$emit(CONST.CONFIRMACTIVE, { 'open': false });
+                });
+
                 modalInstance.result.then(function (selectedItem) {
                     callback(selectedItem);
                 });


### PR DESCRIPTION
This is only partial fix.

This PR re-implements the recent fix whose PR was approved but wasn't merged.
