### PR TITLE
motions.dir: update supporters from operation response

### DIFF
--- a/app/scripts/motions.directive.js
+++ b/app/scripts/motions.directive.js
@@ -52,6 +52,7 @@ angular.module('dashboard')
                     if (angular.isObject(resp) && angular.isObject(resp.motion)) {
                         $log.log("dbMotions.sign done", resp);
                         angular.merge(aMotion, resp.motion);
+                        aMotion.supporters = resp.motion.supporters; // Merge won't handle removals
                     }
                     else {
                         $log.error("dbMotions.sign done ", resp);

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "dependencies": {
     "angular": "^1.5.3",
     "bootstrap-sass-official": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "devDependencies": {
     "autoprefixer": "^6.3.5",


### PR DESCRIPTION
There's a delay if app waits for event. Also merge produces duplicates when an array is merged.
