### PR TITLE
motions.dir: restore scrolling position on model change

### DIFF
--- a/app/scripts/motions.directive.js
+++ b/app/scripts/motions.directive.js
@@ -22,17 +22,48 @@ angular.module('dashboard')
             self.meetingActive = null;
             var selectedMotion = null;
             var mtgItemSelected = StorageSrv.getKey(CONST.KEY.MEETING_ITEM);
+            var scrollTimer = null;
+            var setDataTimer = null;
 
             // FUNCTIONS
 
+            function getScrollingParent(aEl) {
+                var element = angular.isObject(aEl) ? aEl.parentElement : null;
+                while (element) {
+                    if (element.scrollHeight !== element.clientHeight) {
+                        return element;
+                    }
+                    element = element.parentElement;
+                }
+                return element;
+            }
+
             function setMotions(data) {
+                var elm = getScrollingParent(document.getElementById("motionElement")); // Mobile and Desktop DOMS are different, simply find first the scrolling ancestor
+                self.scrollTop = angular.isObject(elm) ? elm.scrollTop : null;
+
                 self.motions = [];
-                $timeout(function () {
+                setDataTimer = $timeout(function () {
                     if (angular.isObject(data)) {
                         self.motions = (angular.isArray(data.objects)) ? data.objects : [];
                         self.motionsCont = data;
+
+                        if (self.scrollTop) {
+                            scrollTimer = $timeout(function () {
+                                $log.debug("dbMotions.setMotions, after timeout scrollTop=" + self.scrollTop + " scrolling parent classList=", elm ? elm.classList : '');
+                                if (self.scrollTop) {
+                                    // Changing model array resets scrolling so
+                                    // restore scroll position here to avoid user having to scroll back down.
+                                    // Model array instance is change is a workaround for wrong textarea
+                                    // scrollHeight got by db- textarea if an array item with smaller index is removed.
+                                    elm.scrollTop = self.scrollTop;
+                                }
+                                self.scrollTop = 0;
+                            }, 0);
+                        }
+
                     }
-                    $log.debug("dbMotions.setMotions, after timeout data:", data);
+                    $log.debug("dbMotions.setMotions, after timeout data=", data);
                 }, 0);
             }
 
@@ -198,6 +229,14 @@ angular.module('dashboard')
                 $log.debug("dbMotions: DESTROY");
                 if (angular.isFunction(modeWatcher)) {
                     modeWatcher();
+                }
+
+                if (angular.isFunction(setDataTimer)) {
+                    setDataTimer();
+                }
+
+                if (angular.isFunction(scrollTimer)) {
+                    scrollTimer();
                 }
             });
 

--- a/app/views/motions.directive.html
+++ b/app/views/motions.directive.html
@@ -9,7 +9,7 @@
         </div>
     </div>
 
-    <div ng-if="!c.motionsCont.failure && !c.motionsCont.loading" class="db-min-width-300">
+    <div id="motionElement" ng-if="!c.motionsCont.failure && !c.motionsCont.loading" class="db-min-width-300">
         <ul class="list-group db-no-margin db-brd-all db-overflow-hidden">
             <div class="db-font-clr-white db-prim-bg db-padding-10 db-no-margin db-brd-top row">
                 <h5 class="col-xs-6 col-md-4 db-truncate" translate translate-cloak>STR_TITLE</h5>


### PR DESCRIPTION
Works around the problem of:
when motion model array is replaced using a different instance (which is a workaround for bad textarea scrollHeight after previous array item was removed), scrolling position jumps to top.
Side effects:
User may see flicker depending on browser performance.
Expanded collapse position is not reverted, location jumps to top of expanded collapse.
