### PR TITLE
help.mtg: clear URL location on destroy event

### DIFF
--- a/app/scripts/controllers/help.mtg.ctrl.js
+++ b/app/scripts/controllers/help.mtg.ctrl.js
@@ -12,7 +12,7 @@
  * Controller of the dashboard
  */
 angular.module('dashboard')
-    .controller('helpDialogCtrl', ['$rootScope', '$log', '$location', '$anchorScroll', function ($rootScope, $log, $location, $anchorScroll) {
+    .controller('helpDialogCtrl', ['$rootScope', '$log', '$location', '$anchorScroll', '$scope', '$timeout', function ($rootScope, $log, $location, $anchorScroll, $scope, $timeout) {
         $log.debug("helpDialogCtrl: anchorScroll");
 
         var self = this;
@@ -20,9 +20,18 @@ angular.module('dashboard')
             return $rootScope.mtgStatusClass(arg);
         };
 
-        $location.hash('id-help-hdr');
+        $location.hash('id-help-hdr'); // Fragment needed to have anchorScroll scroll to top. Must be removed later when controller dismissed.
         $anchorScroll();
-        // Remove added URL hash when it serves no purpose anymore,
-        // also therwise scrolling works only on first time beause location is already at the added hash.
-        $location.hash('');
+
+        $scope.$on('$destroy', function () {
+            $log.debug("helpDialogCtrl: DESTROY");
+            // Location hash change here in destroy event handler needs and apply wrapper to update URL immediately if ngDialog was dismissed via backdrop click,
+            // BUT not if event comes due to closing via close button because apply wrapper already applied by angular (!)
+            // Workaround is to use $timeout zero which works for both.
+            $timeout(function () {
+                // Remove added URL hash when it serves no purpose anymore,
+                // therwise scrolling does not works on second time because location is already at the added id.
+                $location.hash('');
+            }, 0);
+        });
     }]);


### PR DESCRIPTION
Previous synchronous clearing does not work always.
Scrolling id should be removed from url to allow anchorScroll work also on 2nd time dialog is opened.
