### PR TITLE
Motion item textarea scrollHeight updating improved

### DIFF
--- a/app/scripts/controllers/meeting.status.ctrl.js
+++ b/app/scripts/controllers/meeting.status.ctrl.js
@@ -257,10 +257,8 @@ angular.module('dashboard')
                             if (angular.isObject(element) && angular.equals(element.motionGuid, aEvent.motion.motionGuid)) {
                                 data.objects.splice(index, 1);
                                 found = true;
+                                StorageSrv.setKey(CONST.KEY.MOTION_DATA, data);
                             }
-                        }
-                        if (found) {
-                            StorageSrv.setKey(CONST.KEY.MOTION_DATA, data);
                         }
                     }
                 }
@@ -442,7 +440,7 @@ angular.module('dashboard')
                 }, function (error) {
                     $log.error("meetingStatusCtrl.getMotions: error: ", error);
                     motionData.failure = true;
-                    }, function (/*notification*/) {
+                }, function (/*notification*/) {
                     var notificationData = angular.copy(motionData);
                     notificationData.loading = true;
                     notificationData.failure = false;

--- a/app/scripts/motions.directive.js
+++ b/app/scripts/motions.directive.js
@@ -27,40 +27,12 @@ angular.module('dashboard')
 
             // FUNCTIONS
 
-            function getScrollingParent(aEl) {
-                var element = angular.isObject(aEl) ? aEl.parentElement : null;
-                while (element) {
-                    if (element.scrollHeight !== element.clientHeight) {
-                        return element;
-                    }
-                    element = element.parentElement;
-                }
-                return element;
-            }
-
             function setMotions(data) {
-                var elm = getScrollingParent(document.getElementById("motionElement")); // Mobile and Desktop DOMS are different, simply find first the scrolling ancestor
-                self.scrollTop = angular.isObject(elm) ? elm.scrollTop : null;
-
                 self.motions = [];
                 setDataTimer = $timeout(function () {
                     if (angular.isObject(data)) {
                         self.motions = (angular.isArray(data.objects)) ? data.objects : [];
                         self.motionsCont = data;
-
-                        if (self.scrollTop) {
-                            scrollTimer = $timeout(function () {
-                                $log.debug("dbMotions.setMotions, after timeout scrollTop=" + self.scrollTop + " scrolling parent classList=", elm ? elm.classList : '');
-                                if (self.scrollTop) {
-                                    // Changing model array resets scrolling so
-                                    // restore scroll position here to avoid user having to scroll back down.
-                                    // Model array instance is change is a workaround for wrong textarea
-                                    // scrollHeight got by db- textarea if an array item with smaller index is removed.
-                                    elm.scrollTop = self.scrollTop;
-                                }
-                                self.scrollTop = 0;
-                            }, 0);
-                        }
 
                     }
                     $log.debug("dbMotions.setMotions, after timeout data=", data);

--- a/app/scripts/textarea.directive.js
+++ b/app/scripts/textarea.directive.js
@@ -17,40 +17,22 @@ angular.module('dashboard')
             restrict: 'A',
             require: 'ngModel',
             replace: 'true',
-            link: function (scope, element, attrs, ngModel) {
-                var timer;
+            link: function (scope, element/*, attrs, ngModel*/) {
+                var timer = null;
+
                 scope.$watch(
                     function () {
-                        return ngModel.$modelValue;
+                        var res = angular.isObject(element) ? element[0].scrollHeight : null;
+                        return res;
                     },
                     function () {
                         $timeout.cancel(timer);
                         timer = $timeout(function () {
-                            timer = null;
-                            // Sometimes rarely scrollHeight is zero,
-                            // workaround by trying first after a small delay
-                            // and then for the second time if still zero
                             var height = element[0].scrollHeight;
+                            element.css('height', height + 'px');
+                            // $log.debug("dbTextarea: watch new height=" + height + " old=" + aOld +" model: " +JSON.stringify(ngModel.$modelValue).substr(0,30));
 
-                            if (height) {
-                                // $log.debug("dbTextarea.link: 1st try on height ok");
-                                element.css('height', height + 'px');
-                            } else {
-                                // $log.debug("dbTextarea.link: 1st try on height failed");
-                                timer = $timeout(function () {
-                                    timer = null;
-                                    var heightB = angular.isObject(element) ? element[0].scrollHeight : undefined;
-                                    if (heightB) {
-                                        // $log.debug("dbTextarea.link: 2nd try on height=" + heightB);
-                                        element.css('height', heightB + 'px');
-                                    } else {
-                                        // $log.debug("dbTextarea.link: 2nd try on height failed");
-                                    }
-                                }, 300);
-
-                            }
-
-                        }, 0);
+                        }, 0); // Async updating avoids $digest max loop count limit
 
                     },
                     true

--- a/app/scripts/textarea.directive.js
+++ b/app/scripts/textarea.directive.js
@@ -32,7 +32,7 @@ angular.module('dashboard')
                             element.css('height', height + 'px');
                             // $log.debug("dbTextarea: watch new height=" + height + " old=" + aOld +" model: " +JSON.stringify(ngModel.$modelValue).substr(0,30));
 
-                        }, 0); // Async updating avoids $digest max loop count limit
+                        }, 100); // Async updating avoids $digest max loop count limit
 
                     },
                     true


### PR DESCRIPTION
Improves a workaround for an issue where motions are listed in view but an item might have a wrong textarea height after an event removed or added an another item before the item
Observed if three consecutive items have each a different row count, hard to observer otherwise.

Previous approach observed textarea model changes, this observes element scrollHeight layouted by browser.

@hamalmar please do test this before merging, thanks.
